### PR TITLE
feat(calibre-web): Change image tag to use the values instead of chart appVersion

### DIFF
--- a/vista/cailbre-web/templates/deployment.yaml
+++ b/vista/cailbre-web/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{ toYaml .Values.env | nindent 12 }}


### PR DESCRIPTION
Hey 👋 

I'm using you chart and wanted to bump to the latest version but the templating make use of the chart AppVersion and I can't override that. Would you consider this change? Or bump to the latest version maybe?

Thanks a lot by the way to publish this chart, it's the only viable at the moment 😅 